### PR TITLE
feat: ブロックの引数を丸い枠から四角い枠へ変更した。

### DIFF
--- a/src/extensions/smt_kanirobo2/index.js
+++ b/src/extensions/smt_kanirobo2/index.js
@@ -187,7 +187,7 @@ class Kanirobo2 {
                     opcode: 'command2',
                     text: formatMessage({
                         id: 'kanirobo2.command2',
-                        default: 'Initialize motor [TEXT] GPIO',
+                        default: 'Initialize motor [TEXT] GPIO ',
                     }),		    		    
                     blockType: BlockType.COMMAND,
                     arguments: {
@@ -359,27 +359,27 @@ class Kanirobo2 {
 	    //ドロップボックスメニューを使う場合は以下に定義が必要
             menus: {
                 menu1: {
-                    acceptReporters: true,
+                    acceptReporters: false,
                     items: this.MENU1
                 },
                 menu2: {
-                    acceptReporters: true,
+                    acceptReporters: false,
                     items: this.MENU2
                 },
                 menu3: {
-                    acceptReporters: true,
+                    acceptReporters: false,
                     items: this.MENU3
                 },
                 menu4: {
-                    acceptReporters: true,
+                    acceptReporters: false,
                     items: this.MENU4
                 },
                 menu5: {
-                    acceptReporters: true,
+                    acceptReporters: false,
                     items: this.MENU5
                 },
                 menu6: {
-                    acceptReporters: true,
+                    acceptReporters: false,
                     items: this.MENU6
                 },
             }

--- a/src/extensions/smt_rboard/index.js
+++ b/src/extensions/smt_rboard/index.js
@@ -153,7 +153,7 @@ class Rboard {
                     arguments: {
                         NUM1: {
                             type: ArgumentType.STRING,
-			    menu: 'menu3',
+			                menu: 'menu3',
                             defaultValue: LedMenu.led1
                         },
                     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/be42d0e4-83ec-4461-9dc2-13b5db708378)
画像のモータ(1)のGPIOを初期化の(1)のような丸い枠のところをGPIO 出力:[LED1]を使うの[LED1]のような感じの四角い枠に変更した。(他のブロックも同様に)